### PR TITLE
생각해보니 기존 로직에 버그가 있어서 수정합니다.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,35 +19,50 @@ jobs:
           echo "I am protected!"
           sleep 5
 
+  two_clients_test_setup:
+    runs-on: ubuntu-latest
+    name: Set up two clients test
+    needs: [simple_test]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Plant faulty lock (step 1)
+        run: |
+          # Prevent dequeue
+          sed -i "/^  post-entrypoint:/d" ./action.yml
+      - name: Plant faulty lock (step 2)
+        uses: ./
+        with:
+          branch: gh-mutex-two-clients-test
+
   two_clients_test_client_1:
     runs-on: ubuntu-latest
     name: Two clients test (client 1)
-    needs: [simple_test]
+    needs: [two_clients_test_setup]
     steps:
       - uses: actions/checkout@v3
       - name: Set up mutex
         uses: ./
         with:
           branch: gh-mutex-two-clients-test
-          force-unlock-timeout: 20
+          force-unlock-timeout: 21
       - run: |
           echo "I am protected! (Client 1)"
-          sleep 50
+          sleep 20
 
   two_clients_test_client_2:
     runs-on: ubuntu-latest
     name: Two clients test (client 2)
-    needs: [simple_test]
+    needs: [two_clients_test_setup]
     steps:
       - uses: actions/checkout@v3
       - name: Set up mutex
         uses: ./
         with:
           branch: gh-mutex-two-clients-test
-          force-unlock-timeout: 20
+          force-unlock-timeout: 21
       - run: |
           echo "I am protected! (Client 2)"
-          sleep 50
+          sleep 20
 
   debug_test:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: 'gh-mutex'
   force-unlock-timeout:
-    description: 'The time in seconds after which the lock is forcefully unlocked'
+    description: 'The time in seconds after which the queue is forcibly unlocked. If set, should be longer than the max expected run time of the jobs.'
     required: false
     default: ''
   debug:


### PR DESCRIPTION
- dequeue_head 가 성공할 때까지 재시도하면, 동시에 여러 job이 처음에는 같은 head를 dequeue하려 했어도, 결과적으로 한 job만 의도한 head를 디큐하고 다른 job들은 의도치 않은 것들까지 디큐해버릴 수 있는 버그 수정

- 기존에는 큐에 많이 쌓였을 때 여러 job을 기다리느라 timeout을 초과해도 force unlock 발생합니다. 따라서 queue 의 max run time x max queue length 로 타임아웃을 설정해야 하는데, 이건 실용적이 못해서, 단일 job이 타임아웃 넘겼을 때 force unlock 하는걸로 변경합니다. 그럼 timeout은 max run time으로 설정하면 됩니다.